### PR TITLE
Add Asynchronous item searching method

### DIFF
--- a/src/Tests/test_main.py
+++ b/src/Tests/test_main.py
@@ -1,3 +1,5 @@
+import time
+
 import pandas as pd
 import pytest
 from src.Utils import api, database
@@ -12,13 +14,10 @@ class TestMain:
         self.test_Market = api.API()
         self.test_database = database.Database(self.test_Market)
 
-    def test_database_class(self, test_construct_database):
-        assert type(self.test_database.api_data) == pd.DataFrame
-
     def test_database_orders(self, test_construct_database):
         item = "secura_dual_cestra"
-        self.test_database.getOrderDF(item)
-        assert type(self.test_database.api_data) == pd.DataFrame
+        _temp, data = self.test_database.getOrderDF(item)
+        assert type(data) == pd.DataFrame
 
     def test_order_mean_sell(self, test_construct_database):
         item = "secura_dual_cestra"
@@ -26,10 +25,24 @@ class TestMain:
 
     def test_order_mean_buy(self, test_construct_database):
         item = "secura_dual_cestra"
-
         assert 1 < self.test_database.getMeanPlat(item, False) < 300
 
     def test_item_search(self, test_construct_database):
+        start_time = time.time()
         items = ["strun_wraith_receiver", "mantis_set", "fluctus_limbs", "secura_dual_cestra"]
         data = self.test_database.searchItems(items)
+        end_time = time.time()
+        print(end_time - start_time)
         assert type(data) == dict and len(data) == len(items)
+
+    @pytest.mark.parametrize("threads", [i for i in range(1,5)])
+    def test_item_async_search(self, test_construct_database, threads):
+        start_time = time.time()
+        items = ["strun_wraith_receiver", "mantis_set", "fluctus_limbs", "secura_dual_cestra"]
+        data = self.test_database.searchItemsAsync(items, threads)
+        end_time = time.time()
+        print(end_time - start_time)
+        assert type(data) == dict and len(data) == len(items)
+
+
+

--- a/src/Tests/test_main.py
+++ b/src/Tests/test_main.py
@@ -35,11 +35,10 @@ class TestMain:
         print(end_time - start_time)
         assert type(data) == dict and len(data) == len(items)
 
-    @pytest.mark.parametrize("threads", [i for i in range(1,5)])
     def test_item_async_search(self, test_construct_database, threads):
         start_time = time.time()
         items = ["strun_wraith_receiver", "mantis_set", "fluctus_limbs", "secura_dual_cestra"]
-        data = self.test_database.searchItemsAsync(items, threads)
+        data = self.test_database.searchItemsAsync(items)
         end_time = time.time()
         print(end_time - start_time)
         assert type(data) == dict and len(data) == len(items)

--- a/src/Utils/api.py
+++ b/src/Utils/api.py
@@ -5,7 +5,6 @@ import requests
 from tkinter import filedialog
 from src.Utils import utils
 
-
 class API:
     UPDATE_THRESHOLD = dt.timedelta(days=10)  # Threshold in which to sync the local files
     CONFIG_PATH = "config.txt"  # Path to config file
@@ -15,13 +14,12 @@ class API:
     data_dir = ""  # Directory in which
 
     def __init__(self):
-        self.time_at_open = dt.datetime.now()  # Get current time at process open, and save as variable
         # If config does not exist, create from scratch
         if not path.exists(self.CONFIG_PATH):
             # Prompt for directory to store API data in
             self.data_dir = filedialog.askdirectory(mustexist=True, initialdir="..", title="Select a directory for "
                                                                                            "the local data")
-            self.__updateConfig(self.time_at_open, self.data_dir, self.aleca_dir)
+            self.__updateConfig(dt.datetime.now(), self.data_dir, self.aleca_dir)
             self.__apiSync(True)  # Make new config file, and use prefs for API syncing
         else:
             self.__apiSync()  # Sync data if needed
@@ -37,7 +35,7 @@ class API:
         self.__api_timestamp, self.data_dir, self.aleca_dir = utils.readConfig()  # Fetch config settings
         # If later than UPDATE_THRESHOLD days,
         # then sync the local API file to the API itself and write down new timestamp
-        if self.__api_timestamp <= self.time_at_open - self.UPDATE_THRESHOLD or manual_sync:
+        if self.__api_timestamp <= dt.datetime.now() - self.UPDATE_THRESHOLD or manual_sync:
             self.__updateApiFile()
 
     def __updateApiFile(self):
@@ -73,4 +71,5 @@ class API:
         args = {"Platform": self.platform}  # Set request params
         headers = {"Include": "item"}  # Set request headers
         # Make GET request for item orders
-        return requests.get(orders_path, params=args, headers=headers).text
+        data = requests.get(orders_path, params=args, headers=headers).text
+        return data

--- a/src/Utils/utils.py
+++ b/src/Utils/utils.py
@@ -53,3 +53,4 @@ def getDFFromAPIJSON(JSON_text, iter_name):
         # Casts the Series object into a Dataframe and then concats to the api_data.
         data = pd.concat([data, pd.DataFrame([pd.Series(key)])])
     return data
+


### PR DESCRIPTION
### Major
- Made method `searchItemAsync` in database.py for multiprocess item searching.
- Created loading bar in terminal that corresponds with the `searchItemAsync` progress.

### Minor
- Changed return statement in `getOrderDF` to return item url back, to correspond with the original data that was getting returned from the item.
- Removed `timeAtOpen` attribute from api.py, and directly use `datetime.now` instead.
- Created test for the `searchItemAsync` method.
- Added time tracking for the item searching tests, to log length of the two tests each.

###Issues

- During creation of the `searchItemAsync` method, a `ValueError` would throw randomly, due to not getting the needed 2 items for the ```Timestamp, dataDirectory = data[:2]``` line (Currently at line 30 in `utils.py`). Could not discover the cause, but it ended up seemingly fixing itself after completing the card. Keep an eye on this, as it may pop up in the future.

Closes #13 