### PR TITLE
Feature/20240313 max min plat

### DIFF
--- a/src/Tests/test_database.py
+++ b/src/Tests/test_database.py
@@ -2,7 +2,7 @@ import time
 
 import pandas as pd
 import pytest
-from src.Utils import api, database
+from src.Utils import api, database, utils
 
 
 class TestMain:
@@ -21,11 +21,13 @@ class TestMain:
 
     def test_order_mean_sell(self, test_construct_database):
         item = "secura_dual_cestra"
-        assert 1 < self.test_database.getMeanPlat(item, True) < 300
+        data = self.test_database.searchItems([item], cache=True)
+        assert 1 < utils.getMeanPlat(data[item], True) < 300
 
     def test_order_mean_buy(self, test_construct_database):
         item = "secura_dual_cestra"
-        assert 1 < self.test_database.getMeanPlat(item, False) < 300
+        data = self.test_database.searchItems([item], cache=True)
+        assert 1 < utils.getMeanPlat(data[item], False) < 300
 
     def test_item_search(self, test_construct_database):
         start_time = time.time()
@@ -35,13 +37,19 @@ class TestMain:
         print(end_time - start_time)
         assert type(data) == dict and len(data) == len(items)
 
-    def test_item_async_search(self, test_construct_database, threads):
+    def test_item_async_search(self, test_construct_database):
         start_time = time.time()
         items = ["strun_wraith_receiver", "mantis_set", "fluctus_limbs", "secura_dual_cestra"]
         data = self.test_database.searchItemsAsync(items)
         end_time = time.time()
         print(end_time - start_time)
         assert type(data) == dict and len(data) == len(items)
+
+    def test_min_max_plat(self, test_construct_database,):
+        items = ["strun_wraith_receiver", "mantis_set", "fluctus_limbs", "secura_dual_cestra"]
+        data = self.test_database.searchItems(items, cache=True)
+        name, price = utils.getMinMax(data, True)
+        assert name == "secura_dual_cestra" and 100 > price > 30
 
 
 

--- a/src/Tests/test_main.py
+++ b/src/Tests/test_main.py
@@ -1,3 +1,5 @@
+import time
+
 import pandas as pd
 import pytest
 from src.Utils import api, database
@@ -12,13 +14,10 @@ class TestMain:
         self.test_Market = api.API()
         self.test_database = database.Database(self.test_Market)
 
-    def test_database_class(self, test_construct_database):
-        assert type(self.test_database.api_data) == pd.DataFrame
-
     def test_database_orders(self, test_construct_database):
         item = "secura_dual_cestra"
-        self.test_database.getOrderDF(item)
-        assert type(self.test_database.api_data) == pd.DataFrame
+        _temp, data = self.test_database.getOrderDF(item)
+        assert type(data) == pd.DataFrame
 
     def test_order_mean_sell(self, test_construct_database):
         item = "secura_dual_cestra"
@@ -26,10 +25,24 @@ class TestMain:
 
     def test_order_mean_buy(self, test_construct_database):
         item = "secura_dual_cestra"
-
         assert 1 < self.test_database.getMeanPlat(item, False) < 300
 
     def test_item_search(self, test_construct_database):
+        start_time = time.time()
         items = ["strun_wraith_receiver", "mantis_set", "fluctus_limbs", "secura_dual_cestra"]
         data = self.test_database.searchItems(items)
+        end_time = time.time()
+        print(end_time - start_time)
         assert type(data) == dict and len(data) == len(items)
+
+    @pytest.mark.parametrize("threads", [i for i in range(1,5)])
+    def test_item_async_search(self, test_construct_database, threads):
+        start_time = time.time()
+        items = ["strun_wraith_receiver", "mantis_set", "fluctus_limbs", "secura_dual_cestra"]
+        data = self.test_database.searchItemsAsync(items, threads)
+        end_time = time.time()
+        print(end_time - start_time)
+        assert type(data) == dict and len(data) == len(items)
+
+
+

--- a/src/Tests/test_main.py
+++ b/src/Tests/test_main.py
@@ -35,11 +35,10 @@ class TestMain:
         print(end_time - start_time)
         assert type(data) == dict and len(data) == len(items)
 
-    @pytest.mark.parametrize("threads", [i for i in range(1,5)])
     def test_item_async_search(self, test_construct_database, threads):
         start_time = time.time()
         items = ["strun_wraith_receiver", "mantis_set", "fluctus_limbs", "secura_dual_cestra"]
-        data = self.test_database.searchItemsAsync(items, threads)
+        data = self.test_database.searchItemsAsync(items)
         end_time = time.time()
         print(end_time - start_time)
         assert type(data) == dict and len(data) == len(items)

--- a/src/Utils/api.py
+++ b/src/Utils/api.py
@@ -5,7 +5,6 @@ import requests
 from tkinter import filedialog
 from src.Utils import utils
 
-
 class API:
     UPDATE_THRESHOLD = dt.timedelta(days=10)  # Threshold in which to sync the local files
     CONFIG_PATH = "config.txt"  # Path to config file
@@ -15,13 +14,12 @@ class API:
     data_dir = ""  # Directory in which
 
     def __init__(self):
-        self.time_at_open = dt.datetime.now()  # Get current time at process open, and save as variable
         # If config does not exist, create from scratch
         if not path.exists(self.CONFIG_PATH):
             # Prompt for directory to store API data in
             self.data_dir = filedialog.askdirectory(mustexist=True, initialdir="..", title="Select a directory for "
                                                                                            "the local data")
-            self.__updateConfig(self.time_at_open, self.data_dir, self.aleca_dir)
+            self.__updateConfig(dt.datetime.now(), self.data_dir, self.aleca_dir)
             self.__apiSync(True)  # Make new config file, and use prefs for API syncing
         else:
             self.__apiSync()  # Sync data if needed
@@ -37,7 +35,7 @@ class API:
         self.__api_timestamp, self.data_dir, self.aleca_dir = utils.readConfig()  # Fetch config settings
         # If later than UPDATE_THRESHOLD days,
         # then sync the local API file to the API itself and write down new timestamp
-        if self.__api_timestamp <= self.time_at_open - self.UPDATE_THRESHOLD or manual_sync:
+        if self.__api_timestamp <= dt.datetime.now() - self.UPDATE_THRESHOLD or manual_sync:
             self.__updateApiFile()
 
     def __updateApiFile(self):
@@ -73,4 +71,5 @@ class API:
         args = {"Platform": self.platform}  # Set request params
         headers = {"Include": "item"}  # Set request headers
         # Make GET request for item orders
-        return requests.get(orders_path, params=args, headers=headers).text
+        data = requests.get(orders_path, params=args, headers=headers).text
+        return data

--- a/src/Utils/database.py
+++ b/src/Utils/database.py
@@ -23,23 +23,7 @@ class Database:
             raw_data = self.api_obj.getItemOrders(item)
         return item, utils.getDFFromAPIJSON(raw_data, "orders")
 
-    def getMeanPlat(self, item, list_sell):
-        """
-        Takes order listings of an item and takes the average buy or sell price
 
-        :param item: Item to get the mean price of.
-        :type item: str
-        :param list_sell: Search for sell price.
-        :type list_sell: bool
-        :return: Average plat price
-        :rtype: long
-        """
-        _temp, data = self.getOrderDF(item)
-        if list_sell:
-            order_avg = data.loc[data['order_type'] == "sell"]
-        else:
-            order_avg = data.loc[data['order_type'] == "buy"]
-        return round(pd.DataFrame.aggregate(order_avg['platinum'], func='mean'), 0)
 
     def searchItems(self, item_list, cache=False):
         """

--- a/src/Utils/database.py
+++ b/src/Utils/database.py
@@ -1,4 +1,3 @@
-import json
 import os.path
 import time
 from pathlib import Path
@@ -22,8 +21,6 @@ class Database:
         if not from_raw:
             raw_data = self.api_obj.getItemOrders(item)
         return item, utils.getDFFromAPIJSON(raw_data, "orders")
-
-
 
     def searchItems(self, item_list, cache=False):
         """

--- a/src/Utils/database.py
+++ b/src/Utils/database.py
@@ -1,13 +1,15 @@
+import json
+import os.path
 import time
 from pathlib import Path
 import pandas as pd
-from src.Utils import utils
+from src.Utils import utils, api
 import multiprocessing as mp
 import tqdm
 
 
 class Database:
-    def __init__(self, api_obj):
+    def __init__(self, api_obj: api):
         self.af_path = self.api_path = ""
         self.api_obj = api_obj
 
@@ -16,8 +18,9 @@ class Database:
         self.api_data = utils.getDFFromAPIJSON(Path(self.api_path).read_text(),
                                                "items")  # Create dataframe from api file
 
-    def getOrderDF(self, item):
-        raw_data = self.api_obj.getItemOrders(item)
+    def getOrderDF(self, item: str, raw_data=None, from_raw=False):
+        if not from_raw:
+            raw_data = self.api_obj.getItemOrders(item)
         return item, utils.getDFFromAPIJSON(raw_data, "orders")
 
     def getMeanPlat(self, item, list_sell):
@@ -38,18 +41,33 @@ class Database:
             order_avg = data.loc[data['order_type'] == "buy"]
         return round(pd.DataFrame.aggregate(order_avg['platinum'], func='mean'), 0)
 
-    def searchItems(self, item_list):
+    def searchItems(self, item_list, cache=False):
         """
         Collects the orders of a list of item URLs and groups them into a dict of dataframes.
 
         :param item_list: Collection of item urls to search for.
         :type item_list: list
+        :param cache: Option to save and use a local copy of the orders of each item if enabled.
+        Will only be needed for debugging only, as it does not resync after copy creation. (Defaults to False)
+        :type cache: bool
         :return: Dict of order dataframes with key matching the item URL
         :rtype: dict
         """
         order_collection = {}
         for item in item_list:
-            _temp, order_collection[item] = self.getOrderDF(item)
+            if cache:
+                item_cache_path = self.data_path + f"/{item}.json"
+                if os.path.exists(item_cache_path):
+                    with open(item_cache_path, "r") as f:
+                        raw_data = f.read()
+                    _temp, order_collection[item] = self.getOrderDF(item, raw_data, from_raw=True)
+                else:
+                    raw_data = self.api_obj.getItemOrders(item)
+                    with open(item_cache_path, "w") as f:
+                        f.write(raw_data)
+                    _temp, order_collection[item] = self.getOrderDF(item, raw_data, from_raw=True)
+            else:
+                _temp, order_collection[item] = self.getOrderDF(item)
         return order_collection
 
     def searchItemsAsync(self, url_list):

--- a/src/Utils/utils.py
+++ b/src/Utils/utils.py
@@ -54,3 +54,20 @@ def getDFFromAPIJSON(JSON_text, iter_name):
         data = pd.concat([data, pd.DataFrame([pd.Series(key)])])
     return data
 
+
+def getMeanPlat(item_df: pd.DataFrame, list_sell):
+    """
+    Takes dataframes of item orders and gets the average buy or sell price from them
+
+    :param item_df: Dataframe of item orders.
+    :param list_sell: Search for sell price.
+    :type list_sell: bool
+    :return: Average plat price
+    :rtype: long
+    """
+    _temp, data = item_df
+    if list_sell:
+        order_avg = data.loc[data['order_type'] == "sell"]
+    else:
+        order_avg = data.loc[data['order_type'] == "buy"]
+    return round(pd.DataFrame.aggregate(order_avg['platinum'], func='mean'), 0)

--- a/src/Utils/utils.py
+++ b/src/Utils/utils.py
@@ -55,19 +55,46 @@ def getDFFromAPIJSON(JSON_text, iter_name):
     return data
 
 
-def getMeanPlat(item_df: pd.DataFrame, list_sell):
+def getMeanPlat(item_df: pd.DataFrame, get_sell):
     """
     Takes dataframes of item orders and gets the average buy or sell price from them
 
     :param item_df: Dataframe of item orders.
-    :param list_sell: Search for sell price.
-    :type list_sell: bool
+    :param get_sell: Search for sell price.
+    :type get_sell: bool
     :return: Average plat price
     :rtype: long
     """
-    _temp, data = item_df
-    if list_sell:
-        order_avg = data.loc[data['order_type'] == "sell"]
+    if get_sell:
+        order_avg = item_df.loc[item_df['order_type'] == "sell"]
     else:
-        order_avg = data.loc[data['order_type'] == "buy"]
+        order_avg = item_df.loc[item_df['order_type'] == "buy"]
     return round(pd.DataFrame.aggregate(order_avg['platinum'], func='mean'), 0)
+
+
+def getMinMax(orders_df_dict: dict, get_sell):
+    """
+    Takes item orders dataframe, finds mean plat of each, and finds the best sell/buy item and its value.
+
+    :param orders_df_dict: Dictionary of items and their order dataframe as its value.
+    :param get_sell: Get the max selling item in the list if true, otherwise get the min buying item in the list.
+    :type get_sell: bool
+    :return: best priced item name, best priced item price
+    :rtype: tuple[str, int]
+    """
+    mean_plat_dict = {}
+    for item_name in orders_df_dict:
+        # Get mean plat prices from dataframes
+        mean_plat_dict[item_name] = getMeanPlat(orders_df_dict[item_name], get_sell)
+
+    if get_sell:
+        # Get max sell item and value from mean prices
+        best_item_price, best_item_name = max(zip(mean_plat_dict.values(), mean_plat_dict.keys()))
+    else:
+        # Get min buy item and value from mean prices
+        best_item_price, best_item_name = min(zip(mean_plat_dict.values(), mean_plat_dict.keys()))
+
+    if best_item_price - round(best_item_price) == 0:  # If whole number, truncate decimal places
+        best_item_price = round(best_item_price)
+
+    return best_item_name, best_item_price  # Return best item name and price

--- a/src/Utils/utils.py
+++ b/src/Utils/utils.py
@@ -53,3 +53,4 @@ def getDFFromAPIJSON(JSON_text, iter_name):
         # Casts the Series object into a Dataframe and then concats to the api_data.
         data = pd.concat([data, pd.DataFrame([pd.Series(key)])])
     return data
+


### PR DESCRIPTION
> [!CAUTION]
> This pull request must be reviewed and merged after #14 as it bases itself on commits pushed from it.
### Major
- Added `getMinMax` function to take in the dictionary of dataframes in the selection, and find either the minimum buyable item/price in the list, or the maximum sellable item/price. 
- Refined `getMeanPlat` function to take in the raw orders dataframe instead of calling the `getOrderDF` method and having that send out an API request itself. 
   - This is due to the necessity of the newly implemented async item search method and it having to be called independently before this `getMeanPlat` function is called. 
   - This also allows for more control of using parameter settings (namely the `cache` param referenced later) without having to pass them into `getMeanPlat` that would inefficiently also be passed into the search method.
   - Turned it into a static function inside of `utils.py` because of this, as it no longer calls the method from its class.

### Minor
- Added caching debug parameter in the `searchItems` method that will allow for usage and caching of local data instead of calling the API multiple times during development for the same item.
   -  `searchItemsAsync` will be a bit harder to implement this feature into, due to having to call the API request method in the async stream function, with the inability to pass a condition on doing so.

### Future features
- Implement a setting in final release to let user also cache their searches, with the condition that the order data is not too old (1 day?)
- Implement debug caching into `searchItemsAsync`, especially if -as seen above- will be used for the final product in some way by the user in a non-debug way.

Closes #10 