### PR TITLE
Feature/20240319 fuzzy searching

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ python-dateutil==2.8.2
 pytz==2024.1
 pyviz_comms==3.0.1
 PyYAML==6.0.1
+rapidfuzz==3.6.2
 requests==2.31.0
 six==1.16.0
 tornado==6.4

--- a/src/Tests/test_database.py
+++ b/src/Tests/test_database.py
@@ -29,7 +29,7 @@ class TestMain:
         data = self.test_database.searchOrders([item], cache=True)
         assert 1 < utils.getMeanPlat(data[item], False) < 300
 
-    def test_item_search(self, test_construct_database):
+    def test_order_search(self, test_construct_database):
         start_time = time.time()
         items = ["strun_wraith_receiver", "mantis_set", "fluctus_limbs", "secura_dual_cestra"]
         data = self.test_database.searchOrders(items)
@@ -37,7 +37,7 @@ class TestMain:
         print(end_time - start_time)
         assert type(data) == dict and len(data) == len(items)
 
-    def test_item_async_search(self, test_construct_database):
+    def test_order_async_search(self, test_construct_database):
         start_time = time.time()
         items = ["strun_wraith_receiver", "mantis_set", "fluctus_limbs", "secura_dual_cestra"]
         data = self.test_database.searchOrdersAsync(items)
@@ -50,6 +50,12 @@ class TestMain:
         data = self.test_database.searchOrders(items, cache=True)
         name, price = utils.getMinMax(data, True)
         assert name == "secura_dual_cestra" and 100 > price > 30
+
+    def test_item_search(self, test_construct_database):
+        query = "magus"
+        results = self.test_database.searchItems(query).index.tolist()[:5]
+        assert results == ['Magus Vigor', 'Magus Repair', 'Magus Glitch', 'Magus Overload', 'Magus Anomaly']
+
 
 
 

--- a/src/Tests/test_database.py
+++ b/src/Tests/test_database.py
@@ -21,18 +21,18 @@ class TestMain:
 
     def test_order_mean_sell(self, test_construct_database):
         item = "secura_dual_cestra"
-        data = self.test_database.searchItems([item], cache=True)
+        data = self.test_database.searchOrders([item], cache=True)
         assert 1 < utils.getMeanPlat(data[item], True) < 300
 
     def test_order_mean_buy(self, test_construct_database):
         item = "secura_dual_cestra"
-        data = self.test_database.searchItems([item], cache=True)
+        data = self.test_database.searchOrders([item], cache=True)
         assert 1 < utils.getMeanPlat(data[item], False) < 300
 
     def test_item_search(self, test_construct_database):
         start_time = time.time()
         items = ["strun_wraith_receiver", "mantis_set", "fluctus_limbs", "secura_dual_cestra"]
-        data = self.test_database.searchItems(items)
+        data = self.test_database.searchOrders(items)
         end_time = time.time()
         print(end_time - start_time)
         assert type(data) == dict and len(data) == len(items)
@@ -40,14 +40,14 @@ class TestMain:
     def test_item_async_search(self, test_construct_database):
         start_time = time.time()
         items = ["strun_wraith_receiver", "mantis_set", "fluctus_limbs", "secura_dual_cestra"]
-        data = self.test_database.searchItemsAsync(items)
+        data = self.test_database.searchOrdersAsync(items)
         end_time = time.time()
         print(end_time - start_time)
         assert type(data) == dict and len(data) == len(items)
 
     def test_min_max_plat(self, test_construct_database,):
         items = ["strun_wraith_receiver", "mantis_set", "fluctus_limbs", "secura_dual_cestra"]
-        data = self.test_database.searchItems(items, cache=True)
+        data = self.test_database.searchOrders(items, cache=True)
         name, price = utils.getMinMax(data, True)
         assert name == "secura_dual_cestra" and 100 > price > 30
 

--- a/src/Utils/api.py
+++ b/src/Utils/api.py
@@ -5,6 +5,7 @@ import requests
 from tkinter import filedialog
 from src.Utils import utils
 
+
 class API:
     UPDATE_THRESHOLD = dt.timedelta(days=10)  # Threshold in which to sync the local files
     CONFIG_PATH = "config.txt"  # Path to config file
@@ -19,7 +20,7 @@ class API:
             # Prompt for directory to store API data in
             self.data_dir = filedialog.askdirectory(mustexist=True, initialdir="..", title="Select a directory for "
                                                                                            "the local data")
-            self.__updateConfig(dt.datetime.now(), self.data_dir, self.aleca_dir)
+            self.__updateConfig(dt.datetime.strftime(dt.datetime.now(), "%Y-%m-%d %H:%M:%S.%f"), self.data_dir, self.aleca_dir)
             self.__apiSync(True)  # Make new config file, and use prefs for API syncing
         else:
             self.__apiSync()  # Sync data if needed

--- a/src/Utils/database.py
+++ b/src/Utils/database.py
@@ -1,3 +1,4 @@
+import functools
 import os.path
 import time
 from pathlib import Path
@@ -68,3 +69,10 @@ class Database:
                     time.sleep(1)
                 api_num += 1
         return results_list
+
+    def getItemURLDict(self):
+        itemDict = {}
+        with open(self.api_path, "r") as f:
+            rawData = f.read()
+        api_df = utils.getDFFromAPIJSON(rawData, "items")
+        print(api_df)

--- a/src/Utils/database.py
+++ b/src/Utils/database.py
@@ -12,11 +12,30 @@ class Database:
     def __init__(self, api_obj: api):
         self.af_path = self.api_path = ""
         self.api_obj = api_obj
+        self.items_df = None
 
         temp, self.data_path, self.af_path = utils.readConfig()  # Get data paths from config
         self.api_path = self.data_path + "/ApiData.json"  # Get local api path from data directory
         self.api_data = utils.getDFFromAPIJSON(Path(self.api_path).read_text(),
                                                "items")  # Create dataframe from api file
+
+        self.__getItemURLDict()  # Create Item name/URL dict
+
+    def __getItemURLDict(self):
+        """
+        Creates a dictionary of each item's name and corresponding URL, saving it into the 'items_df' attribute.
+        """
+
+        # Open ApiData.json and read its data.
+        with open(self.api_path, "r") as f:
+            rawData = f.read()
+
+        api_df = utils.getDFFromAPIJSON(rawData, "items")  # Make dataframe from JSON data
+
+        # Process and clean dataframe
+        # Turn dataframe into dictionary of key-value pair of item name, with value of the item url.
+        api_df = api_df[["item_name", "url_name"]].set_index("item_name").to_dict()
+        self.items_df = api_df["url_name"]  # Save dictionary to attribute
 
     def getOrderDF(self, item: str, raw_data=None, from_raw=False):
         if not from_raw:
@@ -69,12 +88,5 @@ class Database:
                     time.sleep(1)
                 api_num += 1
         return results_list
-
-    def getItemURLDict(self):
-        with open(self.api_path, "r") as f:
-            rawData = f.read()
-        api_df = utils.getDFFromAPIJSON(rawData, "items")
-        api_df = api_df[["item_name", "url_name"]].set_index("item_name").to_dict()
-        return api_df["url_name"]
 
 

--- a/src/Utils/database.py
+++ b/src/Utils/database.py
@@ -23,7 +23,7 @@ class Database:
             raw_data = self.api_obj.getItemOrders(item)
         return item, utils.getDFFromAPIJSON(raw_data, "orders")
 
-    def searchItems(self, item_list, cache=False):
+    def searchOrders(self, item_list, cache=False):
         """
         Collects the orders of a list of item URLs and groups them into a dict of dataframes.
 
@@ -52,7 +52,7 @@ class Database:
                 _temp, order_collection[item] = self.getOrderDF(item)
         return order_collection
 
-    def searchItemsAsync(self, url_list):
+    def searchOrdersAsync(self, url_list):
         """
         Asynchronous version of `searchItems` method.
         :param url_list: List of item URL's to search for

--- a/src/Utils/database.py
+++ b/src/Utils/database.py
@@ -71,8 +71,10 @@ class Database:
         return results_list
 
     def getItemURLDict(self):
-        itemDict = {}
         with open(self.api_path, "r") as f:
             rawData = f.read()
         api_df = utils.getDFFromAPIJSON(rawData, "items")
-        print(api_df)
+        api_df = api_df[["item_name", "url_name"]].set_index("item_name").to_dict()
+        return api_df["url_name"]
+
+

--- a/src/Utils/database.py
+++ b/src/Utils/database.py
@@ -17,7 +17,7 @@ class Database:
         temp, self.data_path, self.af_path = utils.readConfig()  # Get data paths from config
         self.api_path = self.data_path + "/ApiData.json"  # Get local api path from data directory
         self.api_data = utils.getDFFromJSON(Path(self.api_path).read_text(),
-                                               "items")  # Create dataframe from api file
+                                            "items")  # Create dataframe from api file
 
         self.__getItemURLDict()  # Create Item name/URL dict
 
@@ -79,7 +79,7 @@ class Database:
     def searchOrdersAsync(self, url_list):
         """
         Asynchronous version of `searchItems` method.
-        :param url_list: List of item URL's to search for
+        :param url_list: List of item URLs to search for
         :type url_list: list[str]
         :return:
         :rtype: dict[pandas.DataFrame]
@@ -116,5 +116,3 @@ class Database:
         search_results_df.set_index("Name", inplace=True)
 
         return search_results_df
-
-

--- a/src/Utils/utils.py
+++ b/src/Utils/utils.py
@@ -35,7 +35,7 @@ def readConfig():
     return Timestamp, dataDirectory, alecaDirectory  # Return settings
 
 
-def getDFFromAPIJSON(JSON_text, iter_name):
+def getDFFromJSON(JSON_text, iter_name):
     """
     Takes JSON encoded text and parses it into a dataframe object.
 


### PR DESCRIPTION
### Major

- Made method `getItemURLDict` method to get ApiData.json item name and url and put it into a dataframe
   - Saves it to an attribute of 'database' class
   - 'database' class will call this method on init, thus giving the updated dataframe on class construction.
- Added new `searchItems` method to do a fuzzy search on a search query, and return the results.
- Added test for `searchItems` method


### Minor

- Changed anything pertaining to "searchItems" to "searchOrders", to better reflect the functions of the methods, as the new item search method got created in this merge.
- Removed unnecessary raw data functionality from `getOrderDF` and changed any code blocks that needed the functionality to use existing `getDFFromJSON` instead.
- Fixed mismatched datatype being put into the config in API data with datetime.
- Updated requirements.txt 

Closes #16 